### PR TITLE
Fix for issue https://github.com/mwanji/humpty/issues/6

### DIFF
--- a/src/main/java/co/mewf/humpty/config/HumptyBootstrap.java
+++ b/src/main/java/co/mewf/humpty/config/HumptyBootstrap.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
 import java.net.URL;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -181,7 +182,7 @@ public class HumptyBootstrap implements PipelineElement {
       
       while (urls.hasMoreElements()) {
         URL url = urls.nextElement();
-        Files.walk(Paths.get(url.getFile()))
+        Files.walk(Paths.get(url.toURI()))
           .filter(path -> path.toFile().isFile())
           .map(Path::toString)
           .map(path -> path.substring(path.indexOf(fullAssetsDir) + 1))
@@ -191,7 +192,7 @@ public class HumptyBootstrap implements PipelineElement {
       assetPaths.addAll(new WebJarAssetLocator().getFullPathIndex().values());
       
       return new WebJarAssetLocator(assetPaths);
-    } catch (IOException e) {
+    } catch (IOException | URISyntaxException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
This pull request fixes the problem identified in issue #6 with the solution presented there.   Note that not all the tests pass for me after this change, but at least not all of them are failing.

```
Failed tests:   
  should_concatenate_bundle_with_multiple_assets(co.mewf.humpty.PipelineTest): expected:<... synchronize, write;[
  should_compile_bundle(co.mewf.humpty.PipelineTest): expected:<... synchronize, write;[
  should_process_asset_within_bundle(co.mewf.humpty.Pipeline_SingleAssetTest): expected:<... synchronize, write;[

Tests in error: 
  should_resolve_files_in_subdirectory_of_custom_assetsDir(co.mewf.humpty.spi.resolvers.WebJarResolverTest): java.lang.IllegalArgumentException: sub/asset2.js could not be found. Make sure you've added the corresponding WebJar and please check for typos.
  should_resolve_files_in_default_assetsDir(co.mewf.humpty.spi.resolvers.WebJarResolverTest): java.lang.IllegalArgumentException: asset1.js could not be found. Make sure you've added the corresponding WebJar and please check for typos.
  should_resolve_files_in_custom_assetsDir(co.mewf.humpty.spi.resolvers.WebJarResolverTest): java.lang.IllegalArgumentException: asset1.js could not be found. Make sure you've added the corresponding WebJar and please check for typos.
```
